### PR TITLE
Allow inherited commands in command classes

### DIFF
--- a/core/src/main/java/de/maxhenkel/admiral/impl/AdmiralClass.java
+++ b/core/src/main/java/de/maxhenkel/admiral/impl/AdmiralClass.java
@@ -42,10 +42,11 @@ public class AdmiralClass<S, C> {
         commands = Arrays.asList(clazz.getDeclaredAnnotationsByType(Command.class));
         requiredPermissions = PermissionAnnotationUtil.getPermissions(clazz);
 
-        Method[] declaredMethods = clazz.getDeclaredMethods();
+        HashSet<Method> allMethods = new HashSet<>(Arrays.asList(clazz.getDeclaredMethods()));
+        allMethods.addAll(Arrays.asList(clazz.getMethods()));
 
         int registeredMethods = 0;
-        for (Method method : declaredMethods) {
+        for (Method method : allMethods) {
             method.setAccessible(true);
             if (method.getDeclaredAnnotationsByType(Command.class).length == 0) {
                 continue;


### PR DESCRIPTION
**Description**

Also call class::getMethods, when checking for command methods, this will include any inherited public methods   allowing command inheritance

